### PR TITLE
Add additional argument seconds argument for clock.tick.

### DIFF
--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,9 +413,14 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
+    PyObject *seconds = NULL;
 
-    if (!PyArg_ParseTuple(arg, "|f", &framerate))
+    if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
+    int return_in_seconds = 0;
+    if(seconds && PyObject_IsTrue(seconds)) {
+        return_in_seconds = 1;
+    }
 
     if (framerate) {
         int delay, endtime = (int)((1.0f / framerate) * 1000.0f);
@@ -463,7 +468,12 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
+    if(return_in_seconds) {
+        return(PyFloat_FromDouble(_clock->timepassed / 1000.0));
+    }
+    else {
     return PyLong_FromLong(_clock->timepassed);
+    }
 }
 
 static PyObject *

--- a/src_c/time.c
+++ b/src_c/time.c
@@ -413,12 +413,13 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
     PyClockObject *_clock = (PyClockObject *)self;
     float framerate = 0.0f;
     int nowtime;
+    int return_in_seconds = 0;
     PyObject *seconds = NULL;
 
     if (!PyArg_ParseTuple(arg, "|f0", &framerate, &seconds))
         return NULL;
-    int return_in_seconds = 0;
-    if(seconds && PyObject_IsTrue(seconds)) {
+    
+    if (seconds && PyObject_IsTrue(seconds)) {
         return_in_seconds = 1;
     }
 
@@ -468,12 +469,12 @@ clock_tick_base(PyObject *self, PyObject *arg, int use_accurate_delay)
         _clock->fps_tick = nowtime;
         Py_XDECREF(_clock->rendered);
     }
-    if(return_in_seconds) {
-        return(PyFloat_FromDouble(_clock->timepassed / 1000.0));
+    if (return_in_seconds) {
+        return PyFloat_FromDouble(_clock->timepassed / 1000.0);
     }
-    else {
+
     return PyLong_FromLong(_clock->timepassed);
-    }
+    
 }
 
 static PyObject *

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -173,56 +173,6 @@ class ClockTypeTest(unittest.TestCase):
     @unittest.skipIf(
         os.environ.get("CI", None), "CI can have variable time slices, slow."
     )
-    def test_tick_with_seconds(self):
-    """Tests time.Clock.tick() with the seconds argument"""
-    # Adjust this value to increase the acceptable seconds jitter
-    epsilon_seconds = 0.005  
-
-    testing_framerate = 60
-    milliseconds = 5.0
-    seconds = milliseconds / 1000  
-
-    c = Clock()
-    collection_seconds = []
-
-    
-    c.tick(seconds=True)  # Initialize the clock
-    for i in range(100):
-        time.sleep(seconds)  
-        collection_seconds.append(c.tick(seconds=True))
-
-    # Remove the first highest and lowest value
-    for outlier in [min(collection_seconds), max(collection_seconds)]:
-        if abs(outlier - seconds) > epsilon_seconds:
-            collection_seconds.remove(outlier)
-
-    average_time_seconds = sum(collection_seconds) / len(collection_seconds)
-
-    # Assert the deviation from the intended delay in seconds is within the acceptable amount
-    self.assertAlmostEqual(average_time_seconds, seconds, delta=epsilon_seconds)
-
-    # Test frame-rate control with seconds=True
-    c = Clock()
-    collection_seconds = []
-
-    start = time.time()
-
-    for i in range(testing_framerate):
-        collection_seconds.append(c.tick(testing_framerate, seconds=True))
-
-    end = time.time()
-
-    # Calculate the expected duration in seconds for the given framerate
-    expected_duration = testing_framerate / testing_framerate
-
-    # Assert the duration with seconds=True is within an acceptable margin
-    self.assertAlmostEqual(end - start, expected_duration, delta=epsilon_seconds)
-
-    # Calculate the average tick time in seconds and assert it's close to the expected frame duration in seconds
-    average_tick_time_seconds = sum(collection_seconds) / len(collection_seconds)
-    expected_frame_duration_seconds = 1 / testing_framerate
-    self.assertAlmostEqual(average_tick_time_seconds, expected_frame_duration_seconds, delta=epsilon_seconds)
-
 
     def test_tick_busy_loop(self):
         """Test tick_busy_loop"""


### PR DESCRIPTION
Setting seconds=True changes the return type to seconds instead of the ms used by default.